### PR TITLE
Fixed Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
 
 before_install:
   - export CXX=g++-4.8 CC=gcc-4.8
+  - sudo apt-get update
   - sudo apt-get -y install python3-pip python-dev
   - sudo pip3 install -U pip setuptools virtualenvwrapper
   - python3 -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ matrix:
 before_install:
   - export CXX=g++-4.8 CC=gcc-4.8
   - sudo apt-get update
-  - sudo apt-get -y install python3-pip python-dev
-  - sudo pip3 install -U pip setuptools virtualenvwrapper
+  - sudo apt-get -y install python3-pip python3-setuptools python-dev
+  - sudo pip3 install -U pip virtualenvwrapper
   - python3 -V
   - pip3 -V
   - virtualenv -p python3 venv

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![pinetree](https://github.com/clauswilke/pinetree/blob/master/docs/pinetree-logo.png?raw=true)
 
 # pinetree 
-[![Build Status](https://travis-ci.org/clauswilke/pinetree.svg?branch=master)](https://travis-ci.org/benjaminjack/pinetree)
+[![Build Status](https://travis-ci.org/clauswilke/pinetree.svg?branch=master)](https://travis-ci.org/clauswilke/pinetree)
 [![Documentation Status](https://readthedocs.org/projects/pinetree/badge/?version=latest)](http://pinetree.readthedocs.io/en/latest/?badge=latest)
 
 A flexible gene expression simulator with codon-specific translation rates.


### PR DESCRIPTION
A dependency of setup.py (setuptools) wasn't being installed correctly.

Fixed by using apt-get instead of pip. Apparently using pip to install setuptools usually fails (although I couldn't find an answer as to why this is the case).