### PR TITLE
Fixed Read the Docs build failure

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 breathe == 4.5.0
-cmake == 0.8.0
+cmake == 3.14.4
 ./


### PR DESCRIPTION
Read the Docs uses a version of pip that can't install older versions of cmake (exact reason has to do with references to files/directories that no long exist in the pip source). Installing a more recent version of cmake fixes the problem

This closes #5 