### PR TITLE
Fix reference cycle that causes model objects to leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,8 @@ celerybeat-schedule
 # virtualenv
 venv/
 ENV/
+env-pinetree-release/
+valgrind-tests/
 
 # Spyder project settings
 .spyderproject

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ _skbuild
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
+pip-wheel-metadata
 
 # Unit test / coverage reports
 htmlcov/

--- a/src/pinetree/model.cpp
+++ b/src/pinetree/model.cpp
@@ -89,8 +89,7 @@ void Model::RegisterGenome(Genome::Ptr genome) {
   RegisterPolymer(genome);
   genome->termination_signal_.ConnectMember(
       &SpeciesTracker::Instance(), &SpeciesTracker::TerminateTranscription);
-  genome->transcript_signal_.ConnectMember(shared_from_this(),
-                                           &Model::RegisterTranscript);
+  genome->transcript_signal_.ConnectMember(this, &Model::RegisterTranscript);
   genomes_.push_back(genome);
 }
 

--- a/src/pinetree/polymer.cpp
+++ b/src/pinetree/polymer.cpp
@@ -112,10 +112,12 @@ Polymer::Polymer(const std::string &name, int start, int stop)
 }
 
 Polymer::~Polymer() {
-  // Error check to make sure nothing is uncovered
-  // and no polymerases are bound
+  // The following code can be uncommented to check that
+  // polymers are being properly destroyed during the simulation,
+  // i.e. nothing is left uncovered/ no polymerases are bound. 
+  // For debugging purposes only. 
   //
-  // std::cout << "Begin destroying polymer." << std::endl;
+  /*std::cout << "Begin destroying polymer." << std::endl;
   if (polymerases_.pol_count() != 0) {
     std::cout << "WARNING: Attempting to destruct Polymer object with "
                  "Polymerases still "
@@ -135,7 +137,7 @@ Polymer::~Polymer() {
                   << std::endl;
       }
     }
-  }
+  }*/
 }
 
 void Polymer::Unlink() {


### PR DESCRIPTION
This fixes a reference cycle that was preventing the central model object from being properly destroyed.

Model stores a shared pointer to a signal object which stores another shared pointer back to model. To break the cycle, model is connect to the signal via a raw pointer instead. The class supports both shared pointers and raw pointers, so no additional changes are required.
