### PR TITLE
Support for individual rnase binding rates at internal sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+valgrind-tests/
 
 # Translations
 *.mo
@@ -108,6 +109,7 @@ celerybeat-schedule
 # virtualenv
 venv/
 ENV/
+env-pinetree-release/
 
 # Spyder project settings
 .spyderproject

--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,6 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
-valgrind-tests/
 
 # Translations
 *.mo
@@ -110,6 +109,7 @@ celerybeat-schedule
 venv/
 ENV/
 env-pinetree-release/
+valgrind-tests/
 
 # Spyder project settings
 .spyderproject

--- a/docs/python_ref.rst
+++ b/docs/python_ref.rst
@@ -16,4 +16,25 @@ Model
 Genome
 ------
 .. autoclass:: Genome
-    :members:
+    :members: add_gene, add_mask, add_promoter, add_terminator, add_weights
+    
+    .. method:: add_rnase_site(name, start, stop, rate)
+
+        Define an Rnase cleavage site.
+        
+        :param name: A unique identifier for this RNase cleavage site.
+        :type name: string
+        :param start: Start position of RNase cleavage site.
+        :type start: int
+        :param stop: Stop position of RNase cleavage site.
+        :type stop: int
+        :param rate: Binding rate constant between RNase and this cleavage site.
+        :type rate: float
+
+        .. note::
+
+            The internal RNase binding rate constant can alternatively be supplied as an 
+            argument during Genome initialization (see ``Genome`` class description above).
+            In this case, ``add_rnase_site()`` will only accept values for start and stop,
+            and all rnase binding sites will be initialized with the same rate constant. 
+            Warning: This method is deprecated and may be removed in the future.

--- a/src/pinetree/model.cpp
+++ b/src/pinetree/model.cpp
@@ -134,7 +134,6 @@ void Model::Initialize() {
           rnase_template_ext, "__rnase_site_ext");
       auto &tracker = SpeciesTracker::Instance();
       tracker.Add("__rnase_site_ext", reaction_ext);
-      // tracker.Add("__rnase", reaction_ext);
       gillespie_.LinkReaction(reaction_ext);
     }
     
@@ -149,7 +148,6 @@ void Model::Initialize() {
           "__rnase_site");
       auto &tracker = SpeciesTracker::Instance();
       tracker.Add("__rnase_site", reaction);
-      // tracker.Add("__rnase", reaction);
       gillespie_.LinkReaction(reaction);
     } 
     
@@ -162,7 +160,6 @@ void Model::Initialize() {
           rnase_site.second, cell_volume_, rnase_template, rnase_site.first);
         auto &tracker = SpeciesTracker::Instance();
         tracker.Add(rnase_site.first, reaction);
-        // tracker.Add("__rnase", reaction);
         gillespie_.LinkReaction(reaction);
       }
     }

--- a/src/pinetree/model.cpp
+++ b/src/pinetree/model.cpp
@@ -125,6 +125,7 @@ void Model::Initialize() {
         }
       }
     }
+    
     if (genome->transcript_degradation_rate() != 0.0) {
       // TODO: user defined Rnase speed
       // auto rnase_template = Rnase(10, 30);
@@ -137,12 +138,15 @@ void Model::Initialize() {
       tracker.Add("__rnase_site", reaction);
       // tracker.Add("__rnase", reaction);
       gillespie_.LinkReaction(reaction);
-    
+    }
+
+    if (genome->transcript_degradation_rate_ext() != 0.0) {
       auto rnase_template_ext =
           Rnase(genome->rnase_footprint(), genome->rnase_speed());
       auto reaction_ext = std::make_shared<BindRnase>(
           genome->transcript_degradation_rate_ext(), cell_volume_,
           rnase_template_ext, "__rnase_site_ext");
+      auto &tracker = SpeciesTracker::Instance();
       tracker.Add("__rnase_site_ext", reaction_ext);
       // tracker.Add("__rnase", reaction_ext);
       gillespie_.LinkReaction(reaction_ext);

--- a/src/pinetree/model.cpp
+++ b/src/pinetree/model.cpp
@@ -137,7 +137,7 @@ void Model::Initialize() {
       tracker.Add("__rnase_site", reaction);
       // tracker.Add("__rnase", reaction);
       gillespie_.LinkReaction(reaction);
-
+    
       auto rnase_template_ext =
           Rnase(genome->rnase_footprint(), genome->rnase_speed());
       auto reaction_ext = std::make_shared<BindRnase>(
@@ -146,9 +146,23 @@ void Model::Initialize() {
       tracker.Add("__rnase_site_ext", reaction_ext);
       // tracker.Add("__rnase", reaction_ext);
       gillespie_.LinkReaction(reaction_ext);
+    } 
+    
+    if (genome->rnase_bindings().size() != 0) {
+      for (auto rnase_site : genome->rnase_bindings()) {
+        auto rnase_template =
+          Rnase(genome->rnase_footprint(), genome->rnase_speed());
+        auto reaction = std::make_shared<BindRnase>(
+          rnase_site.second, cell_volume_, rnase_template,
+          rnase_site.first);
+        auto &tracker = SpeciesTracker::Instance();
+        tracker.Add(rnase_site.first, reaction);
+        // tracker.Add("__rnase", reaction);
+        gillespie_.LinkReaction(reaction);
+      }
     }
   }
-
+  
   // Initialize transcripts that have been defined independently of genome
   for (Transcript::Ptr transcript : transcripts_) {
     for (auto rbs_name : transcript->bindings()) {

--- a/src/pinetree/polymer.cpp
+++ b/src/pinetree/polymer.cpp
@@ -656,9 +656,9 @@ const std::map<std::string, std::map<std::string, double>>
 }
 
 Genome::Genome(const std::string &name, int length,
-               double transcript_degradation_rate,
                double transcript_degradation_rate_ext,
-               double rnase_speed, double rnase_footprint)
+               double rnase_speed, double rnase_footprint,
+               double transcript_degradation_rate)
     : Polymer(name, 1, length),
       transcript_degradation_rate_(transcript_degradation_rate),
       transcript_degradation_rate_ext_(transcript_degradation_rate_ext),
@@ -743,11 +743,13 @@ void Genome::AddRnaseSite(const std::string &name, int start,
 
   // First check that transcript_degredation_rate_ is still set to zero
   if (transcript_degradation_rate_ != 0.0) {
-    throw std::runtime_error(
-        "Cannot add unique rnase site if global transcript_degredation_rate 
-        is set. Please see pinetree documentation for details");
+    std::string err = 
+      "Cannot add unique rnase site if global transcript_degredation_rate " 
+      "is set. Please see pinetree documentation for details";
+    throw std::runtime_error(err);
+        
   }
-  
+
   auto binding =
       std::map<std::string, double>{{"__rnase", transcript_degradation_rate}};
   auto rnase_site =

--- a/src/pinetree/polymer.cpp
+++ b/src/pinetree/polymer.cpp
@@ -734,21 +734,35 @@ void Genome::AddRnaseSite(int start, int stop) {
       std::make_shared<BindingSite>("__rnase_site", start, stop, binding);
   transcript_rbs_intervals_.emplace_back(rnase_site->start(),
                                          rnase_site->stop(), rnase_site);
-  std::cout << "created rnase site with afinity: " << transcript_degradation_rate_ << std::endl;
 }
 
 //Overloading allows for user to specify a rnase rate constant unique to this site
 //while maintaining backwards compatability
 void Genome::AddRnaseSite(const std::string &name, int start, 
                           int stop, double transcript_degradation_rate) {
+
+  // First check that transcript_degredation_rate_ is still set to zero
+  if (transcript_degradation_rate_ != 0.0) {
+    throw std::runtime_error(
+        "Cannot add unique rnase site if global transcript_degredation_rate 
+        is set. Please see pinetree documentation for details");
+  }
+  
   auto binding =
       std::map<std::string, double>{{"__rnase", transcript_degradation_rate}};
   auto rnase_site =
       std::make_shared<BindingSite>(name, start, stop, binding);
   transcript_rbs_intervals_.emplace_back(rnase_site->start(),
                                          rnase_site->stop(), rnase_site);
-  rnase_bindings_[name] = transcript_degradation_rate;
-  std::cout << "created rnase site with afinity: " << transcript_degradation_rate << std::endl;
+
+  //rnase sites need to have unique names
+  //Otherwise propensity calculations will be incorrect                                      
+  if (rnase_bindings_.count(name) != 0) {
+    throw std::runtime_error(
+        "Rnase site name '" + name + "' already in use.");
+  } else {
+    rnase_bindings_[name] = transcript_degradation_rate;
+  }
 }
 
 void Genome::AddWeights(const std::vector<double> &transcript_weights) {

--- a/src/pinetree/polymer.cpp
+++ b/src/pinetree/polymer.cpp
@@ -665,13 +665,10 @@ Genome::Genome(const std::string &name, int length,
       rnase_speed_(rnase_speed),
       rnase_footprint_(rnase_footprint) {
   transcript_weights_ = std::vector<double>(length, 1.0);
-  if (transcript_degradation_rate_ != 0 || rnase_speed_ != 0 ||
-      rnase_footprint_ != 0) {
-    if (!(transcript_degradation_rate_ != 0 && rnase_speed_ != 0 &&
-          rnase_footprint_ != 0)) {
+  if (transcript_degradation_rate_ext != 0 || transcript_degradation_rate != 0) {
+    if (!(rnase_speed_ != 0 && rnase_footprint_ != 0)) {
       throw std::runtime_error(
-          "Please specify 'transcript_degradation_rate', 'rnase_speed', and "
-          "'rnase_footprint' to enable transcript degradation.");
+        "Please specify 'rnase_speed' and/or 'rnase_footprint'");
     }
   }
 }
@@ -742,7 +739,8 @@ void Genome::AddRnaseSite(int start, int stop) {
 
 //Overloading allows for user to specify a rnase rate constant unique to this site
 //while maintaining backwards compatability
-void Genome::AddRnaseSite(const std::string &name, int start, int stop, double transcript_degradation_rate) {
+void Genome::AddRnaseSite(const std::string &name, int start, 
+                          int stop, double transcript_degradation_rate) {
   auto binding =
       std::map<std::string, double>{{"__rnase", transcript_degradation_rate}};
   auto rnase_site =

--- a/src/pinetree/polymer.hpp
+++ b/src/pinetree/polymer.hpp
@@ -470,8 +470,10 @@ class Genome : public Polymer {
   void AddGene(const std::string &name, int start, int stop, int rbs_start,
                int rbs_stop, double rbs_strength);
   void AddRnaseSite(int start, int stop);
+  void AddRnaseSite(const std::string &name, int start, int stop, double rnase_degradation_rate);
   void AddWeights(const std::vector<double> &transcript_weights);
   const std::map<std::string, std::map<std::string, double>> &bindings();
+  const std::map<std::string, double> &rnase_bindings() { return rnase_bindings_; }
   const double &transcript_degradation_rate() {
     return transcript_degradation_rate_;
   }
@@ -501,6 +503,7 @@ class Genome : public Polymer {
   IntervalTree<ReleaseSite::Ptr> transcript_stop_sites_;
   std::vector<double> transcript_weights_;
   std::map<std::string, std::map<std::string, double>> bindings_;
+  std::map<std::string, double> rnase_bindings_;
   double transcript_degradation_rate_ = 0.0;
   double transcript_degradation_rate_ext_ = 0.0;
   double rnase_speed_ = 0.0;

--- a/src/pinetree/polymer.hpp
+++ b/src/pinetree/polymer.hpp
@@ -458,9 +458,8 @@ class Genome : public Polymer {
    *  the cell)
    */
   Genome(const std::string &name, int length,
-         double transcript_degradation_rate = 0.0,
          double transcript_degradation_rate_ext = 0.0, double rnase_speed = 0.0,
-         double rnase_footprint = 0.0);
+         double rnase_footprint = 0.0, double transcript_degradation_rate = 0.0);
   void Initialize();
   void AddMask(int start, const std::vector<std::string> &interactions);
   void AddPromoter(const std::string &name, int start, int stop,

--- a/src/pinetree/python_bindings.cpp
+++ b/src/pinetree/python_bindings.cpp
@@ -433,7 +433,7 @@ PYBIND11_MODULE(core, m) {
 
             )doc")
       .def("add_rnase_site", &Genome::AddRnaseSite, "start"_a, "stop"_a, "rate"_a);*/
-      .def("add_rnase_site", (void (Genome::*)(int, int)) &Genome::AddRnaseSite,
+      .def("add_rnase_site", (void (Genome::*)(int, int)) &Genome::AddRnaseSite, "start"_a, "stop"_a,
            R"doc(
             
             Define an internal RNase cleavage site.
@@ -443,7 +443,8 @@ PYBIND11_MODULE(core, m) {
                 stop (int): Stop position of RNase cleavage site.
 
             )doc")
-      .def("add_rnase_site", (void (Genome::*)(const std::string&, int, int, double)) &Genome::AddRnaseSite);
+      .def("add_rnase_site", (void (Genome::*)(const std::string&, int, int, double)) &Genome::AddRnaseSite, 
+      "name"_a, "start"_a, "stop"_a, "rate"_a);
 
   py::class_<Transcript, Polymer, Transcript::Ptr>(m, "Transcript")
       .def(py::init<const std::string &, int>(), "name"_a, "length"_a,

--- a/src/pinetree/python_bindings.cpp
+++ b/src/pinetree/python_bindings.cpp
@@ -307,10 +307,10 @@ PYBIND11_MODULE(core, m) {
   // Polymers, genomes, and transcripts
   py::class_<Polymer, Polymer::Ptr>(m, "Polymer");
   py::class_<Genome, Polymer, Genome::Ptr>(m, "Genome")
-      .def(py::init<const std::string &, int, double, double, double, int>(),
-           "name"_a, "length"_a, "transcript_degradation_rate"_a = 0.0,
-           "transcript_degradation_rate_ext"_a = 0.0, "rnase_speed"_a = 0.0,
-           "rnase_footprint"_a = 0,
+      .def(py::init<const std::string &, int, double, double, int, double>(),
+           "name"_a, "length"_a, "transcript_degradation_rate_ext"_a = 0.0, 
+           "rnase_speed"_a = 0.0, "rnase_footprint"_a = 0,
+           "transcript_degradation_rate"_a = 0.0,
            R"doc(
             
             Define a linear genome. 
@@ -318,9 +318,6 @@ PYBIND11_MODULE(core, m) {
             Args:
                 name (str): Name of genome.
                 length (int): Length of genome in base pairs.
-                transcript_degradation_rate (float): Unary binding rate 
-                    constant for binding of RNases to internal RNase sites. 
-                    (See the add_rnase_site() method below.)
                 transcript_degradation_rate_ext (float): Unary binding rate 
                     constant for binding of RNases to the 5'-end of transcripts.
                 rnase_speed (flaot): Mean speed at which RNase degrades 
@@ -422,29 +419,20 @@ PYBIND11_MODULE(core, m) {
                     and ribosome binding site.
 
             )doc")
-      /*.def("add_rnase_site", &Genome::AddRnaseSite, "start"_a, "stop"_a,
-           R"doc(
-            
-            Define an internal RNase cleavage site.
-
-            Args:
-                start (int): Start position of RNase cleavage site.
-                stop (int): Stop position of RNase cleavage site.
-
-            )doc")
-      .def("add_rnase_site", &Genome::AddRnaseSite, "start"_a, "stop"_a, "rate"_a);*/
-      .def("add_rnase_site", (void (Genome::*)(int, int)) &Genome::AddRnaseSite, "start"_a, "stop"_a,
-           R"doc(
-            
-            Define an internal RNase cleavage site.
-
-            Args:
-                start (int): Start position of RNase cleavage site.
-                stop (int): Stop position of RNase cleavage site.
-
-            )doc")
+      .def("add_rnase_site", (void (Genome::*)(int, int)) &Genome::AddRnaseSite, "start"_a, "stop"_a)
       .def("add_rnase_site", (void (Genome::*)(const std::string&, int, int, double)) &Genome::AddRnaseSite, 
-      "name"_a, "start"_a, "stop"_a, "rate"_a);
+      "name"_a, "start"_a, "stop"_a, "rate"_a,
+            R"doc(
+            
+            Define an internal RNase cleavage site.
+
+            Args:
+                name (string): A unique identifier for this rnase cleavage site.
+                start (int): Start position of rnase cleavage site.
+                stop (int): Stop position of rnase cleavage site.
+                rate (float): Binding rate constant between rnase and cleavage site.
+
+            )doc");
 
   py::class_<Transcript, Polymer, Transcript::Ptr>(m, "Transcript")
       .def(py::init<const std::string &, int>(), "name"_a, "length"_a,

--- a/src/pinetree/python_bindings.cpp
+++ b/src/pinetree/python_bindings.cpp
@@ -422,7 +422,7 @@ PYBIND11_MODULE(core, m) {
                     and ribosome binding site.
 
             )doc")
-      .def("add_rnase_site", &Genome::AddRnaseSite, "start"_a, "stop"_a,
+      /*.def("add_rnase_site", &Genome::AddRnaseSite, "start"_a, "stop"_a,
            R"doc(
             
             Define an internal RNase cleavage site.
@@ -431,7 +431,19 @@ PYBIND11_MODULE(core, m) {
                 start (int): Start position of RNase cleavage site.
                 stop (int): Stop position of RNase cleavage site.
 
-            )doc");
+            )doc")
+      .def("add_rnase_site", &Genome::AddRnaseSite, "start"_a, "stop"_a, "rate"_a);*/
+      .def("add_rnase_site", (void (Genome::*)(int, int)) &Genome::AddRnaseSite,
+           R"doc(
+            
+            Define an internal RNase cleavage site.
+
+            Args:
+                start (int): Start position of RNase cleavage site.
+                stop (int): Stop position of RNase cleavage site.
+
+            )doc")
+      .def("add_rnase_site", (void (Genome::*)(const std::string&, int, int, double)) &Genome::AddRnaseSite);
 
   py::class_<Transcript, Polymer, Transcript::Ptr>(m, "Transcript")
       .def(py::init<const std::string &, int>(), "name"_a, "length"_a,

--- a/src/pinetree/python_bindings.cpp
+++ b/src/pinetree/python_bindings.cpp
@@ -422,29 +422,9 @@ PYBIND11_MODULE(core, m) {
                     and ribosome binding site.
 
             )doc")
-      .def("add_rnase_site", (void (Genome::*)(int, int)) &Genome::AddRnaseSite, "start"_a, "stop"_a)
       .def("add_rnase_site", (void (Genome::*)(const std::string&, int, int, double)) &Genome::AddRnaseSite, 
-      "name"_a, "start"_a, "stop"_a, "rate"_a,
-            R"doc(
-            
-            Define an internal RNase cleavage site.
-
-            Args:
-                name (string): A unique identifier for this RNase cleavage site.
-                start (int): Start position of RNase cleavage site.
-                stop (int): Stop position of RNase cleavage site.
-                rate (float): Binding rate constant between RNase and cleavage site.
-
-            .. note::
-               
-               The internal RNase binding rate constant can alternatively be supplied as an 
-               argument during Genome initialization (see ``Genome`` class description above).
-               In this case, ``add_rnase_site()`` will only accept values for start and stop,
-               and all rnase binding sites will be initialized with the same rate constant. 
-               Warning: This method is deprecated and may be removed in the future.
-
-            )doc");
-
+           "name"_a, "start"_a, "stop"_a, "rate"_a)
+      .def("add_rnase_site", (void (Genome::*)(int, int)) &Genome::AddRnaseSite, "start"_a, "stop"_a);
   py::class_<Transcript, Polymer, Transcript::Ptr>(m, "Transcript")
       .def(py::init<const std::string &, int>(), "name"_a, "length"_a,
            R"doc(

--- a/src/pinetree/python_bindings.cpp
+++ b/src/pinetree/python_bindings.cpp
@@ -323,6 +323,9 @@ PYBIND11_MODULE(core, m) {
                 rnase_speed (flaot): Mean speed at which RNase degrades 
                     transcript, in bases per second.
                 rnase_footprint (float): Initial footprint of RNase on RNA.
+                transcript_degradation_rate (float): Deprecated. Unary binding rate constant for 
+                    binding of RNases to internal RNase sites. (See the add_rnase_site() 
+                    method below for details.)
 
           )doc")
       .def("add_mask", &Genome::AddMask, "start"_a, "interactions"_a,
@@ -427,10 +430,18 @@ PYBIND11_MODULE(core, m) {
             Define an internal RNase cleavage site.
 
             Args:
-                name (string): A unique identifier for this rnase cleavage site.
-                start (int): Start position of rnase cleavage site.
-                stop (int): Stop position of rnase cleavage site.
-                rate (float): Binding rate constant between rnase and cleavage site.
+                name (string): A unique identifier for this RNase cleavage site.
+                start (int): Start position of RNase cleavage site.
+                stop (int): Stop position of RNase cleavage site.
+                rate (float): Binding rate constant between RNase and cleavage site.
+
+            .. note::
+               
+               The internal RNase binding rate constant can alternatively be supplied as an 
+               argument during Genome initialization (see ``Genome`` class description above).
+               In this case, ``add_rnase_site()`` will only accept values for start and stop,
+               and all rnase binding sites will be initialized with the same rate constant. 
+               Warning: This method is deprecated and may be removed in the future.
 
             )doc");
 

--- a/tests/feature_test.py
+++ b/tests/feature_test.py
@@ -116,6 +116,21 @@ class TestMaskMethods(unittest.TestCase):
         mask = pt.Mask(1, 10, {"rnapol": 1.0})
         self.assertTrue(mask.check_interaction("rnapol"))
 
+# Tests that python bindings work for the overloaded "AddRnaseSite" method
+class TestRnaseSiteAdd(unittest.TestCase):
+    def test_add_rnase_site_method(self):
+        plasmid = pt.Genome(name="T7", length=305,
+                            transcript_degradation_rate=1e-2,
+                            transcript_degradation_rate_ext=1e-2,
+                            rnase_footprint=9,
+                            rnase_speed=20)
+        
+        # Original method
+        plasmid.add_rnase_site(start=100, stop=110)
+
+        # alternate method that takes a rnase binding affinity specific to
+        # this site
+        plasmid.add_rnase_site(name="R6.5", start=220, stop=230, rate=5e-3)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/feature_test.py
+++ b/tests/feature_test.py
@@ -118,7 +118,7 @@ class TestMaskMethods(unittest.TestCase):
 
 # Tests that python bindings work for the overloaded "AddRnaseSite" method
 class TestRnaseSiteAdd(unittest.TestCase):
-    def test_add_rnase_site_method(self):
+    def test_overload(self):
         plasmid = pt.Genome(name="T7", length=305,
                             transcript_degradation_rate=1e-2,
                             transcript_degradation_rate_ext=1e-2,
@@ -128,9 +128,40 @@ class TestRnaseSiteAdd(unittest.TestCase):
         # Original method
         plasmid.add_rnase_site(start=100, stop=110)
 
+        plasmid = pt.Genome(name="T7", length=305,
+                            transcript_degradation_rate_ext=1e-2,
+                            rnase_footprint=9,
+                            rnase_speed=20)
+        
         # alternate method that takes a rnase binding affinity specific to
         # this site
         plasmid.add_rnase_site(name="R6.5", start=220, stop=230, rate=5e-3)
+
+    def test_rate_error_handling(self):
+        plasmid = pt.Genome(name="T7", length=305,
+                            transcript_degradation_rate=1e-2,
+                            transcript_degradation_rate_ext=1e-2,
+                            rnase_footprint=9,
+                            rnase_speed=20)
+         
+        # Shouldn't be able to specify a unique binding rate constant if 
+        # transcript_degredation_rate is set
+        with self.assertRaises(RuntimeError):
+            plasmid.add_rnase_site(name="R6.5", start=220, stop=230, rate=5e-3)
+    
+    def test_site_names_error_handling(self):
+        # this time don't set transcript_degredation_rate
+        plasmid = pt.Genome(name="T7", length=305,
+                            transcript_degradation_rate_ext=1e-2,
+                            rnase_footprint=9,
+                            rnase_speed=20)
+
+        plasmid.add_rnase_site(name="R1", start=280, stop=290, rate=4e-3)
+        # rnase binding site names must be unique
+        with self.assertRaises(RuntimeError):
+            plasmid.add_rnase_site(name="R1", start=220, stop=230, rate=5e-3)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -8,7 +8,7 @@
 
 TEST_CASE("Genome construction")
 {
-    auto plasmid = std::shared_ptr<Genome>(new Genome("T7", 305, 0.01, 0.001, 9.0, 20.0));
+    auto plasmid = std::shared_ptr<Genome>(new Genome("T7", 305, 0.001, 9.0, 20, 0.01));
     auto plasmid2 = std::shared_ptr<Genome>(new Genome("T7", 305));
     
     REQUIRE(plasmid->transcript_degradation_rate() == 0.01);


### PR DESCRIPTION
The user can now create internal rnase binding sites with unique binding rate constants by passing the rate constant to the add_rnase_site() method. 

In the older version, a single binding rate constant is passed to the genome constructor, and all cleavage sites are created using that rate. The old method is still supported but the newer method is preferred. I changed the docs to reflect that. I also added some checks and error handling to ensure that users are not mixing methods. Finally, I added some python unit tests for the updated add_rnase_site().