### PR TITLE
fix 'and' operator syntax error in `feature.hpp`

### DIFF
--- a/src/pinetree/feature.hpp
+++ b/src/pinetree/feature.hpp
@@ -41,7 +41,7 @@ class FixedElement : public std::enable_shared_from_this<FixedElement> {
    * Was this element just uncovered?
    * @return True if element was just uncovered.
    */
-  bool WasUncovered() { return old_covered_ >= 1 and covered_ == 0; }
+  bool WasUncovered() { return old_covered_ >= 1 && covered_ == 0; }
   /**
    * Was this element just covered?
    * @return True if element was just covered.


### PR DESCRIPTION
This fixes a syntax error in `feature.hpp` that was caught by a user with a Windows 10 VS code compiler (identification MSVC 19.26.28806.0). 

Not sure why this wasn't caught by other compilers, since it's a pretty basic syntax issue (using "and" instead of "&&")