### PR TITLE
Resolve a race condition in polymer::move that was causing Pinetree to throw an error when a termination site and binding site overlap

### DIFF
--- a/src/pinetree/polymer.cpp
+++ b/src/pinetree/polymer.cpp
@@ -358,6 +358,18 @@ void Polymer::Move(int pol_index) {
     pol->MoveBack();
     return;
   }
+
+    // Check for new covered and uncovered elements
+  if (pol->name() == "__ribosome") {
+    // std::cout << "CheckBehind pol" << std::endl;
+  }
+  CheckBehind(old_start, pol->start());
+  if (pol->name() == "__rnase") {
+    CheckAheadRnase(old_stop, pol->stop());
+  } else {
+    CheckAhead(old_stop, pol->stop());
+  }
+  
   // Check if polymerase has run into a terminator
   bool terminating = CheckTermination(pol_index);
   if (terminating && pol->name() != "__rnase") {
@@ -377,17 +389,6 @@ void Polymer::Move(int pol_index) {
   auto transcript = polymerases_.GetAttached(pol_index);
   if (transcript != nullptr) {
     transcript->ShiftMask();
-  }
-
-  // Check for new covered and uncovered elements
-  if (pol->name() == "__ribosome") {
-    // std::cout << "CheckBehind pol" << std::endl;
-  }
-  CheckBehind(old_start, pol->start());
-  if (pol->name() == "__rnase") {
-    CheckAheadRnase(old_stop, pol->stop());
-  } else {
-    CheckAhead(old_stop, pol->stop());
   }
 
   // Update propensity for new codon (TODO: make its own function)


### PR DESCRIPTION
The issue was that Pinetree was handling uncovering/covering of new sites after handling mobile element termination. 

This is almost always fine, except for the corner case where a termination site (like a stop codon) overlaps the start of another site (like a ribosome binding site). When a mobile element reaches the termination site, it will trigger a removal event, where any overlapping sites are "uncovered" (i.e. the `covered_` counter is decremented by 1). However, since this essentially escapes the checking that Pinetree does for newly covered sites, any site that was also covered during this step will end up with a `covered_` counter that is off by one. This can lead to behavior like ribosomes trying to bind on top of eachother. 

This closes #12 ; I was able to run ~20 different sims (using different seeds) of the complete overlapping T7 genome without error.