### PR TITLE
Change Travis build language to Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-language: cpp
+language: python
 python: 
-  - "3.7"
+  - 3.7
 matrix:
   include:
   - os: linux


### PR DESCRIPTION
Travis was using an older version of Python (3.5) even though CI tests are configured to run with Python 3.7. This went unnoticed for some time, since Pinetree itself is actually compatible with Python 3.5 (unofficially, at least) but another Python dependency of the CI pipeline is no longer compatible with version 3.5.

The solution I came up with just changes the `language` key in `.travis.yml` to `Python` instead of `cpp` (which basically tells Travis to use a slightly different build image). This was probably not the only solution, but I think this is sensible, since Pinetree is called with Python. 