### PR TITLE
Release 0.4.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Pinetree 0.4.0
+
+- Pinetree can now simulate circular genome expression.
+- Updates the catch.hpp dependency to a version that compiles on Apple M1 devices. 
+
 ## Pinetree 0.3.0
 
 - Support for site-specific RNase binding constants.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools.command.test import test as TestCommand
 from shutil import copyfile, copymode
 
 PROJECT_NAME = "pinetree"
-VERSION = "0.3.0"
+VERSION = "0.4.0"
 
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=''):

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,8 @@ class CMakeBuild(build_ext):
         subprocess.check_call(['cmake', '--build', '.'] + build_args,
                               cwd=self.build_temp)
         test_bin = os.path.join(self.build_temp, PROJECT_NAME + '_test')
-        self.copy_test_file(test_bin)
+        if platform.system() != "Windows":
+            self.copy_test_file(test_bin)
         print()  # Add an empty line for cleaner output
 
     def copy_test_file(self, src_file):


### PR DESCRIPTION
Summary:
- Pinetree now supports circular genome expression
- Updated catch2 to a version that compiles on Apple M1